### PR TITLE
Removing default implementation of the props on the Event.dart

### DIFF
--- a/event.dart
+++ b/event.dart
@@ -2,8 +2,5 @@ part of '<rename_file>_bloc.dart';
 
 abstract class <rename>Event extends Equatable {
   const <rename>Event();
-
-  @override
-  List<Object> get props => [];
 }
 


### PR DESCRIPTION
By having a default implementation of the props on the abstract event class, it increases the chances that the developer in forget to override it. So removing it to address that risk.