### PR TITLE
feat: making state concrete class with a named constructor

### DIFF
--- a/state.dart
+++ b/state.dart
@@ -1,10 +1,10 @@
 part of '<rename_file>_bloc.dart';
 
-abstract class <rename>State extends Equatable {
+class <rename>State extends Equatable {
   const <rename>State();
+  
+  const <rename>State.initial() : this();
 
   @override
   List<Object> get props => [];
 }
-
-class <rename>Initial extends <rename>State {}


### PR DESCRIPTION
Small suggestion: make the state a concrete class with a named constructor instead of abstract with an intial implementation.

This is more a matter of taste than with real benefits, but this is a pattern that I see being used a lot.